### PR TITLE
unicornの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,10 @@ group :test do
   gem 'chromedriver-helper'
 end
 
+group :production do
+  gem 'unicorn', '5.4.1'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'


### PR DESCRIPTION
#what
アプリケーションサーバー「unicornーrails」を入れる

#why
アプリケーションサーバー「railsーs」から「unicorn–rails」にするため