### PR TITLE
追加:usersテーブルにbirthdayカラム

### DIFF
--- a/db/migrate/20200416141034_add_birthday_to_user.rb
+++ b/db/migrate/20200416141034_add_birthday_to_user.rb
@@ -1,0 +1,5 @@
+class AddBirthdayToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :birthday, :date
+  end
+end

--- a/db/migrate/20200416141034_add_birthday_to_user.rb
+++ b/db/migrate/20200416141034_add_birthday_to_user.rb
@@ -1,5 +1,5 @@
 class AddBirthdayToUser < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :birthday, :date
+    add_column :users, :birthday, :date, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_15_152659) do
+ActiveRecord::Schema.define(version: 2020_04_16_141034) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -128,6 +128,7 @@ ActiveRecord::Schema.define(version: 2020_04_15_152659) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "address_id"
+    t.date "birthday"
     t.index ["address_id"], name: "index_users_on_address_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -128,7 +128,7 @@ ActiveRecord::Schema.define(version: 2020_04_16_141034) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "address_id"
-    t.date "birthday"
+    t.date "birthday", null: false
     t.index ["address_id"], name: "index_users_on_address_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
# What
追加のための修正マイグレーションファイルを作成
usersテーブルにbirthdayカラム date型 null:false制約 を追加

# Why
本人確認情報の必須項目だったため
