### PR TITLE
修正:addressesのpostal.code

### DIFF
--- a/db/migrate/20200416141034_add_birthday_to_user.rb
+++ b/db/migrate/20200416141034_add_birthday_to_user.rb
@@ -1,5 +1,0 @@
-class AddBirthdayToUser < ActiveRecord::Migration[5.2]
-  def change
-    add_column :users, :birthday, :date, null: false
-  end
-end

--- a/db/migrate/20200420112629_change_postal_code_to_adresses.rb
+++ b/db/migrate/20200420112629_change_postal_code_to_adresses.rb
@@ -1,0 +1,9 @@
+class ChangePostalCodeToAdresses < ActiveRecord::Migration[5.2]
+  def up
+    change_column :addresses, :postal_code, :string
+  end
+
+  def down
+    change_column :addresses, :postal_code, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2020_04_16_141034) do
-
+ActiveRecord::Schema.define(version: 2020_04_20_112629) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "postal_code", null: false
+    t.string "postal_code", null: false
     t.string "prefectures", null: false
     t.string "municipality", null: false
     t.string "building"
@@ -128,7 +126,6 @@ ActiveRecord::Schema.define(version: 2020_04_16_141034) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "address"
     t.bigint "address_id"
     t.index ["address_id"], name: "index_users_on_address_id"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
# What
addressesテーブルのpostal_codeを
integerからstringに変更

# Why
正規表現で郵便番号の(-)ハイフンを入れられるように
するため