### PR TITLE
修正:usersテーブルのbirthdayカラム

### DIFF
--- a/db/migrate/20200426165328_change_birthday_colunm.rb
+++ b/db/migrate/20200426165328_change_birthday_colunm.rb
@@ -1,0 +1,9 @@
+class ChangeBirthdayColunm < ActiveRecord::Migration[5.2]
+  def up
+    change_column :users, :birthday, :date
+  end
+
+  def down
+    change_column :users, :birthday, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_21_134130) do
+ActiveRecord::Schema.define(version: 2020_04_26_165328) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "postal_code", null: false
-    t.string "prefectures", null: false
     t.string "municipality", null: false
     t.string "building"
     t.string "house_number", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "prefectures"
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
@@ -117,7 +117,7 @@ ActiveRecord::Schema.define(version: 2020_04_21_134130) do
     t.integer "sales"
     t.integer "point"
     t.text "icon"
-    t.string "birthday", null: false
+    t.date "birthday", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
# What
usersテーブルのbirthdayカラムの型をstringからdateに修正

# Why
ユーザアビリティの観点から
新規登録の誕生日の入力フォームを簡易的にするため