### PR TITLE
ancestryの修正

### DIFF
--- a/db/migrate/20200501135752_change_datatype_ancestry_of_categoris.rb
+++ b/db/migrate/20200501135752_change_datatype_ancestry_of_categoris.rb
@@ -1,0 +1,6 @@
+class ChangeDatatypeAncestryOfCategoris < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :categoris, :ancestry, :string
+    add_column :categoris, :ancestry, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_30_151905) do
+ActiveRecord::Schema.define(version: 2020_05_01_135752) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -41,9 +41,9 @@ ActiveRecord::Schema.define(version: 2020_04_30_151905) do
 
   create_table "categoris", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "category_name", null: false
-    t.string "ancestry", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "ancestry"
   end
 
   create_table "credit_cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# what
categoriesテーブルのancestryのデータ型修正

# why
データ型を修正することにより、null値を許可し、ancestryの親の値（null）の入力を可能にする。