### PR TITLE
削除:item_imagesテーブルの削除

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,7 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
-    @item.item_images.build
+    # @item.item_images.build
     @categori_parent_array = ["---"]
     @categori_parent_array = Categori.where(ancestry: nil)
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,7 @@ class Item < ApplicationRecord
   # has_many :item_comments
   # has_many :likes
   # has_many :items_statuses
-  has_many :item_images
+  # has_many :item_images
   
   # belongs_to :brand
   belongs_to :user

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   # belongs_to :brand
   belongs_to :user
   belongs_to :categori
-  accepts_nested_attributes_for :item_images
+  # accepts_nested_attributes_for :item_images
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :delivery_fee

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -1,3 +1,0 @@
-class ItemImage < ApplicationRecord
-  belongs_to :item
-end

--- a/db/migrate/20200503114737_drop_item_images.rb
+++ b/db/migrate/20200503114737_drop_item_images.rb
@@ -1,11 +1,13 @@
-class CreateItemImages < ActiveRecord::Migration[5.2]
-  def change
+class DropItemImages < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :item_images
+  end
+
+  def down
     create_table :item_images do |t|
       t.string :image, null: false
       t.integer :item, null: false
       t.timestamps
-    end
+    end  
   end
 end
-
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_01_135752) do
+ActiveRecord::Schema.define(version: 2020_05_03_114737) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_135752) do
   end
 
   create_table "categoris", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "category_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "ancestry"
@@ -51,14 +51,6 @@ ActiveRecord::Schema.define(version: 2020_05_01_135752) do
     t.text "evaluation", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "item_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "image", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "item_id", null: false
-    t.index ["item_id"], name: "index_item_images_on_item_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -132,6 +124,5 @@ ActiveRecord::Schema.define(version: 2020_05_01_135752) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "item_images", "items"
   add_foreign_key "users", "addresses"
 end


### PR DESCRIPTION
# What
active_storageの導入に先駆けて
マイグレファイルを新しく作成し
テーブル及びアソシエーションを削除

item_imagesテーブルを削除した副作用で
以下のビューが少し崩れています
[![Screenshot from Gyazo](https://gyazo.com/9a97a9d82fbc4367f384a0a2d187641a/raw)](https://gyazo.com/9a97a9d82fbc4367f384a0a2d187641a)
avtive_storage実装後修正予定です

# Why
active_storageではデフォルトで画像を
保存するテーブルが自動生成される為
item_imagesテーブルは必要ないという
結論になりました