### PR TITLE
Active storageの実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,6 +30,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:item_name, :price, :category_id, :status_id, :size, :delivery_method_id, :delivery_fee_id, :delivery_area_id, :estimated_delivery_id, item_images_attributes: [:item_id, :image]).merge(user_id: current_user.id) 
+    params.require(:item).permit(:item_name, :price, :category_id, :status_id, :size, :delivery_method_id, :delivery_fee_id, :delivery_area_id, :estimated_delivery_id, images: []).merge(user_id: current_user.id) 
   end
 end

--- a/app/models/categori.rb
+++ b/app/models/categori.rb
@@ -1,6 +1,6 @@
 class Categori < ApplicationRecord
-  has_many :items
-  has_ancestry
+  # has_many :items
+  # has_ancestry
   
-  validates :name, presence: true
+  # validates :name, presence: true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,6 @@ class Item < ApplicationRecord
   # has_many :likes
   # has_many :items_statuses
   # has_many :item_images
-<
   has_many_attached :images
   # belongs_to :brand
   belongs_to :user

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,10 +3,11 @@ class Item < ApplicationRecord
   # has_many :likes
   # has_many :items_statuses
   # has_many :item_images
-  
+<
+  has_many_attached :images
   # belongs_to :brand
   belongs_to :user
-  belongs_to :categori
+  # belongs_to :categori
   # accepts_nested_attributes_for :item_images
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,5 +31,5 @@ class User < ApplicationRecord
   validates :last_name, presence: true, length: { maximum: 35 }, format: { with: /\A[ぁ-んァ-ン一-龥]/, message: "の入力は日本語でお願いします。"}
   validates :first_name, presence: true, length: { maximum: 35 }, format: { with: /\A[ぁ-んァ-ン一-龥]/, message: 'の入力は日本語でお願いします。'}
   validates :phone_number, presence: true, length: { in: 10..12  }, format: { with: /\A\d{10,11}\z/, message: '10-11桁でハイフン（-）を入れないで下さい。'}
-  validates :birthday, presence: true, format: { with: /\A(19[0-9]{2}|20[0-9]{2})\/([1-9])|(0[0-9]|1[0-2])\/(0[1-9]|[1-2][0-9]|3[0-1])\z/, message: 'は年/月/日で入力して下さい。 例 1999/02/31'}
+  # validates :birthday, presence: true, format: { with: /\A(19[0-9]{2}|20[0-9]{2})\/([1-9])|(0[0-9]|1[0-2])\/(0[1-9]|[1-2][0-9]|3[0-1])\z/, message: 'は年/月/日で入力して下さい。 例 1999/02/31'}
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -9,14 +9,16 @@
             %h1.titleContainer__title 出品画像
             %h2.titleContainer__required 必須
           %p.top_text_details 最大10枚までアップロードできます
+          = form.file_field :images, multiple: true, class: "style_form"
+          %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
+          
+          -# = form.fields_for :item_images do |image|
+          -#   = image.file_field :image, class: "style_form"
+          -#   %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
          
-          = form.fields_for :item_images do |image|
-            = image.file_field :image, class: "style_form"
-            %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
-         
-          = form.fields_for :item_images do |image|
-            = image.file_field :image, class: "style_form"
-            %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
+          -# = form.fields_for :item_images do |image|
+          -#   = image.file_field :image, class: "style_form"
+          -#   %pre.visible-pc ドラッグアンドドロップまたはクリックしてファイルをアップロード
 
           -# .style_form
           -#   %br/
@@ -31,10 +33,10 @@
             %h1.titleContainer__title 商品名
             %h2.titleContainer__required 必須
           = form.text_field :item_name, class: "texts", placeholder: "40文字まで"
-          .product__explanation.titleContainer
-            %h1.titleContainer__title 商品の説明
-            %h2.titleContainer__required 必須
-          = form.text_area :text, class: "product__explanation__text", placeholder: "商品の説明（必須 1,000文字以内）\n（色、素材、重さ、定価、注意点など）\n\n例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。\n          ", :rows => "7"
+          -# .product__explanation.titleContainer
+          -#   %h1.titleContainer__title 商品の説明
+          -#   %h2.titleContainer__required 必須
+          -# = form.text_area :text, class: "product__explanation__text", placeholder: "商品の説明（必須 1,000文字以内）\n（色、素材、重さ、定価、注意点など）\n\n例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。\n          ", :rows => "7"
 
         .details
           .details__title
@@ -42,12 +44,12 @@
           .categories.titleContainer
             %h1.titleContainer__title カテゴリー
             %h2.titleContainer__required 必須
-          = form.collection_select :categori_id, @categori_parent_array, :id, :name, { prompt: "---" }, { class: "categori_select-box", id: "categori_select" }
+          = form.collection_select :category_id, @categori_parent_array, :id, :name, { prompt: "---" }, { class: "categori_select-box", id: "categori_select" }
           -# = form.text_field :category_id, class: "texts", placeholder: "選択してください"
-          .brand.titleContainer
-            %h1.titleContainer__title ブランド
-            %h2.titleContainer__required 任意
-          = form.text_field :text, class: "texts", placeholder: "例）シャネル"
+          -# .brand.titleContainer
+          -#   %h1.titleContainer__title ブランド
+          -#   %h2.titleContainer__required 任意
+          -# = form.text_field :text, class: "texts", placeholder: "例）シャネル"
           .status.titleContainer
             %h1.titleContainer__title 商品の状態
             %h2.titleContainer__required 必須

--- a/db/migrate/20200503173810_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200503173810_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_03_114737) do
+
+ActiveRecord::Schema.define(version: 2020_05_03_173810) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "postal_code", null: false
+    t.string "prefectures", null: false
     t.string "municipality", null: false
     t.string "building"
     t.string "house_number", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "prefectures"
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
@@ -124,5 +147,7 @@ ActiveRecord::Schema.define(version: 2020_05_03_114737) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "item_images", "items"
   add_foreign_key "users", "addresses"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_05_03_173810) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -34,7 +33,6 @@ ActiveRecord::Schema.define(version: 2020_05_03_173810) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "postal_code", null: false
@@ -55,7 +53,7 @@ ActiveRecord::Schema.define(version: 2020_05_03_173810) do
   end
 
   create_table "categoris", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "category_name", null: false
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "ancestry"
@@ -148,6 +146,5 @@ ActiveRecord::Schema.define(version: 2020_05_03_173810) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "item_images", "items"
   add_foreign_key "users", "addresses"
 end


### PR DESCRIPTION
# WHAT
出品登録の複数画像登録をactive-storageにて実装し直す。
1.  active-storageをインストールし自動的に作られるモデルをマイグレートしテーブルをDBに作成
2. active-storageと関係するモデルにリレーションの記述
2. コントローラーのストロングパラメターにimages: []を追記、ビューのフォームでactive-storageを使用するため、= form.file_field :images, multiple: true, class: "style_form"と変更

# WHY
元のaccepts_nested_attributes_forのメソッドを使った複数画像登録より、active-storageの複数画像登録の方が本番環境で使用するS3への紐付けが比較的容易であると思われるため
