### PR TITLE
エラーメッセージの追記

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,7 +25,7 @@ class ItemsController < ApplicationController
     # Item.create(item_params)
     @item = Item.new(item_params)
     unless @item.valid?
-      flash.now[:alert] = @item.errors.full_messages
+      # flash.now[:alert] = @item.errors.full_messages
       # helper Form
       render :new and return
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,7 +10,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     @user = User.new(sign_up_params)
     unless @user.valid?
-      flash.now[:alert] = @user.errors.full_messages
+      # flash.now[:alert] = @user.errors.full_messages
       render :new and return
     end
     session["devise.regist_data"] = {user: @user.attributes}

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -31,6 +31,12 @@ module FormHelper
       end                                                                       
     end
 
+    def number_field(attribute, options={})                                       
+      input_field_with_error(attribute, options) do                             
+         super                                                                   
+      end                                                                       
+    end
+    
     def telephone_field(attribute, options={})                                       
       input_field_with_error(attribute, options) do                             
          super                                                                   

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,7 +16,7 @@ class Item < ApplicationRecord
   belongs_to_active_hash :delivery_method
   belongs_to_active_hash :estimated_delivery
   belongs_to_active_hash :status
-
+  
   validates :item_name, presence: true
   validates :price, presence: true
   validates :status_id, presence: true

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -25,7 +25,7 @@
           %tr
             %th カテゴリー
             %td 
-              = @item.category.category_name
+              = @item.category.name
               
               -# %= @items.name
             -# %td 


### PR DESCRIPTION
# what
1. form_helper に number_field を追記
2. items/showのcategory_nameをnameに修正

# why
1. 商品出品機能を完成形に近づけるため
2. 商品詳細ページのエラー解消のため