### PR TITLE
修正:新規登録画面のビューを修正

### DIFF
--- a/app/assets/stylesheets/registrations/registrations_addresses.scss
+++ b/app/assets/stylesheets/registrations/registrations_addresses.scss
@@ -17,7 +17,7 @@ html{
   height: 100%;
   width: 100%;
   .single__header {
-    max-width: 50%;
+    max-width: 20%;
     margin: 0 auto;
     img {
       width: 140px;
@@ -33,7 +33,7 @@ html{
       max-width: 140px;
       margin: 0 auto;
       padding: 30px 10px;
-      font-size: 16px;
+      font-size: 20px;
     }
     .text__main--center {
       padding: 40px 40px 64px;
@@ -41,6 +41,13 @@ html{
       background-color: #fff;
       .text__contents {
         margin: 0 140px;
+        span {
+          margin-left: 8px;
+          padding: 2px 4px;
+          background-color: #ea352d;
+          color: white;
+          border-radius: 2px;
+        }
         .field {
          height: 100%;
          margin-top: 34px;

--- a/app/assets/stylesheets/registrations/registrations_new.scss
+++ b/app/assets/stylesheets/registrations/registrations_new.scss
@@ -13,7 +13,7 @@ html{
   height: 100%;
   width: 100%;
   .single__header {
-    max-width: 50%;
+    max-width: 20%;
     margin: 0 auto;
     img {
       width: 140px;
@@ -35,7 +35,7 @@ html{
     h2.hed {
       max-width: 140px;
       margin: 0 auto;
-      padding: 30px 0 0 20px;
+      padding: 30px 0 20px;
       font-size: 20px;
     }
     p {

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -9,18 +9,22 @@
         .text__contents
           .field
             = f.label :postal_code, "郵便番号"
+            %span 必須
             %br
             = f.text_field :postal_code, :placeholder => "464-9999"
             %br
             = f.label :prefectures, "都道府県"
+            %span 必須
             %br
             = f.select :prefectures, User.prefectures.keys, {prompt: '選択してください'}, class: 'prefecture'
             %br
             = f.label :municipality, "市区町村"
+            %span 必須
             %br
             = f.text_field :municipality, :placeholder => "例南アルプス市天然水"
             %br
             = f.label :house_number, "番地"
+            %span 必須
             %br
             = f.text_field :house_number, :placeholder => "1-2-3"
             %br


### PR DESCRIPTION
# What
新規登録画面のアイコン位置を修正
住所登録の項目に『必須』を追加
[![Screenshot from Gyazo](https://gyazo.com/9d70ef735a82f131256a3123a87bbbda/raw)](https://gyazo.com/9d70ef735a82f131256a3123a87bbbda)

# Why
必須項目を入力しなければ登録されないことを
予めユーザーに周知させるため